### PR TITLE
small css fix to prevent main from overlapping aside on 800-1000px screensizes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -62,17 +62,10 @@ aside:hover{
 #logo {
 	margin-top: 3.6em;
 	display: block;
-<<<<<<< HEAD
 	margin-left: -0.3em;
 	margin-right: auto;
 	min-height: 13%;
 	height: 13%;
-=======
-	margin-left: -0.1em;
-	margin-right: auto;
-	height: 13%;
-	min-height: 13%;
->>>>>>> Adding Responsive Web Design (RWD) meta tag
 }
 
 
@@ -125,7 +118,7 @@ aside a {
 
 /*  ============== MAIN ============== */
 #main {
-	margin: 3% auto auto 14%;
+	margin: 3% auto auto 250px;
 	min-width: 30%;
 	max-width: 70%;
 	min-height: 30em;


### PR DESCRIPTION
Hey,

I found your website super useful but noticed the text in main would overlap the fixed side nav aside at certain screensizes. I changed the left-margin to be a larger fixed size which prevents this problem. 

I also removed a bad merge conflict from #logo.

Feel free to edit the changes - I noticed you tend to use em rather than px - so yeah feel free to edit! 

-Ali

